### PR TITLE
support custom CA bundle for the api-server, and options for MetalLB

### DIFF
--- a/charts/arvados/templates/api-server-deployment.yaml
+++ b/charts/arvados/templates/api-server-deployment.yaml
@@ -49,6 +49,11 @@ spec:
             - name: api-server-configmap
               mountPath: /etc/nginx/sites-enabled/api-server.conf
               subPath: nginx.conf
+            {{- if .Values.customCABundle }}
+            - name: custom-ca-bundle-volume
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: custom-ca-bundle.pem
+            {{- end }}
         - name: arvados-controller
           image: "cure/arvados-runtime"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -86,3 +91,8 @@ spec:
         - name: nginx-configmap
           configMap:
             name: arvados-api-server-https-configmap
+        {{- if .Values.customCABundle }}
+        - name: custom-ca-bundle-volume
+          configMap:
+            name: custom-ca-bundle-configmap
+        {{- end }}

--- a/charts/arvados/templates/api-server-service.yaml
+++ b/charts/arvados/templates/api-server-service.yaml
@@ -11,9 +11,13 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ .Values.loadBalancer.apiServerExternalTrafficPolicy }}
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}
   ports:
   - name: http

--- a/charts/arvados/templates/custom-ca-bundle-configmap.yaml
+++ b/charts/arvados/templates/custom-ca-bundle-configmap.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) The Arvados Authors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-ca-bundle-configmap
+  labels:
+    app: {{ template "arvados.name" . }}
+    chart: {{ template "arvados.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  custom-ca-bundle.pem: |
+{{ .Values.customCABundle | indent 4 }}

--- a/charts/arvados/templates/keep-proxy-service.yaml
+++ b/charts/arvados/templates/keep-proxy-service.yaml
@@ -12,6 +12,10 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}

--- a/charts/arvados/templates/keep-web-service.yaml
+++ b/charts/arvados/templates/keep-web-service.yaml
@@ -12,6 +12,10 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}

--- a/charts/arvados/templates/sso-service.yaml
+++ b/charts/arvados/templates/sso-service.yaml
@@ -11,6 +11,10 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}

--- a/charts/arvados/templates/workbench-deployment.yaml
+++ b/charts/arvados/templates/workbench-deployment.yaml
@@ -49,6 +49,11 @@ spec:
             - name: ssl-configmap
               mountPath: /etc/ssl/private/workbench.key
               subPath: key
+            {{- if .Values.customCABundle }}
+            - name: custom-ca-bundle-volume
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+              subPath: custom-ca-bundle.pem
+            {{- end }}
       volumes:
         - name: etc-configmap
           configMap:
@@ -59,3 +64,9 @@ spec:
         - name: ssl-configmap
           configMap:
             name: ssl-configmap
+        {{- if .Values.customCABundle }}
+        - name: custom-ca-bundle-volume
+          configMap:
+            name: custom-ca-bundle-configmap
+        {{- end }}
+

--- a/charts/arvados/templates/workbench-service.yaml
+++ b/charts/arvados/templates/workbench-service.yaml
@@ -11,6 +11,10 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}

--- a/charts/arvados/templates/ws-service.yaml
+++ b/charts/arvados/templates/ws-service.yaml
@@ -12,6 +12,10 @@ metadata:
     chart: {{ template "arvados.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.loadBalancer.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   type: LoadBalancer
   loadBalancerIP: {{ required "A valid externalIP is required!" .Values.externalIP }}

--- a/charts/arvados/values.yaml
+++ b/charts/arvados/values.yaml
@@ -58,3 +58,8 @@ arvados:
       arvados: 2.0.2
       arvadosCLI: 2.0.2
       arvadosLoginSync: 2.0.2
+
+# A custom bundle of CA certificates to use.
+# Useful for corporate networks with TLS proxies.
+# Set it by using the --set-file Helm argument.
+customCABundle: ""

--- a/charts/arvados/values.yaml
+++ b/charts/arvados/values.yaml
@@ -13,6 +13,17 @@ image:
 # Must be set to a valid IP address, e.g. by using --set when invoking helm
 externalIP: ~
 
+loadBalancer:
+  # Annotations to add to all LoadBalancer Services.
+  # This is required for MetalLB, since the same externalIP is reused for all
+  # services, and sharing is disabled by default.
+  # metallb.universe.tf/allow-shared-ip: arbitrary-sharing-key
+  annotations:
+
+  # externalTrafficPolicy for the api-server-service
+  # Set to Cluster if using MetalLB, otherwise an externalIP won't be allocated
+  apiServerExternalTrafficPolicy: Local
+
 # The default e-mail address and password for the initial cluster admin user
 adminUserEmail: "test@example.com"
 adminUserPassword: "passw0rd"


### PR DESCRIPTION
My corporate network uses TLS inspection, and so a self-signed CA cert needs to be added to the bundle for Internet access.